### PR TITLE
Fix independent bugs found during GTK4 migration review

### DIFF
--- a/TurtleArt/taplugin.py
+++ b/TurtleArt/taplugin.py
@@ -51,8 +51,9 @@ def complete_plugin_install(cls, tmp_dir, tmp_path, plugin_path,
                     create_palette.append(True)
                 else:
                     create_palette.append(False)
-        cls.tw.init_plugin(plugin_name)
-        cls.tw.turtleart_plugins[-1].setup()
+        cls.tw.init_plugin(plugin_name, plugin_path)
+        if plugin_name in cls.tw.turtleart_plugins:
+            cls.tw.turtleart_plugins[plugin_name].setup()
         cls.tw.load_media_shapes()
         for i, palette_name in enumerate(palette_name_list):
             if create_palette[i]:

--- a/TurtleArt/util/configwizard.py
+++ b/TurtleArt/util/configwizard.py
@@ -86,11 +86,12 @@ class ConfigWizard():
             self._do_save_config()
         except Exception as e:
             w = Gtk.Window()
-            ls = Gtk.Label(label=e.message)
+            w.connect('delete_event', lambda widget, event: widget.destroy())
+            ls = Gtk.Label(label=str(e))
             w.add(ls)
             w.show_all()
         finally:
-            self._config_popup.hide()
+            self._config_popup.destroy()
 
     def _do_save_config(self):
         for i in self._config_items:
@@ -135,7 +136,7 @@ class ConfigWizard():
         return hbox
 
     def _close_config_cb(self, widget, event=None):
-        self._config_popup.hide()
+        self._config_popup.destroy()
 
 
 def test_wizard_from_config_file_obj(test_config_file):

--- a/TurtleArt/util/helpbutton.py
+++ b/TurtleArt/util/helpbutton.py
@@ -29,6 +29,7 @@ from sugar3.graphics.icon import Icon
 
 from TurtleArt.tapalette import help_windows
 
+import os
 import logging
 _logger = logging.getLogger('turtleart-activity')
 
@@ -61,6 +62,7 @@ class HelpButton(Gtk.ToolItem):
 class TutorialWindows:
     def __init__(self):
         self.array = []
+        self.base_dir = os.getcwd()
 
         # Current Index of the Window we are at
         self.curr = 0
@@ -74,10 +76,7 @@ class TutorialWindows:
             "\n"
             "\nEvery block inside start is executed after we click the start block.")
 
-        w1.gif_path = "GIF1.gif"
-        w1.anim = GdkPixbuf.PixbufAnimation.new_from_file(w1.gif_path)
-        w1.gif_image = Gtk.Image.new_from_animation(w1.anim)
-        w1.box_gif.pack_start(w1.gif_image, False, False, 0)
+        w1.load_gif(os.path.join(self.base_dir, "GIF1.gif"))
 
         w1.left_arrow.destroy()  # First Window doesn't have a left arrow
         w1.right_arrow.connect("clicked", self.on_right_click)
@@ -96,10 +95,7 @@ class TutorialWindows:
             "\n"
             "\nFinally we move the turtle by the value stored in the box my box_1")
 
-        w2.gif_path = "GIF2.gif"
-        w2.anim = GdkPixbuf.PixbufAnimation.new_from_file(w2.gif_path)
-        w2.gif_image = Gtk.Image.new_from_animation(w2.anim)
-        w2.box_gif.pack_start(w2.gif_image, True, True, 0)
+        w2.load_gif(os.path.join(self.base_dir, "GIF2.gif"))
 
         w2.left_arrow.connect("clicked", self.on_left_click)
         w2.right_arrow.connect("clicked", self.on_right_click)
@@ -114,10 +110,7 @@ class TutorialWindows:
             "\n"
             "\nBy doing so we effectively increase the value stored in my box_1.")
 
-        w3.gif_path = "GIF3.gif"
-        w3.anim = GdkPixbuf.PixbufAnimation.new_from_file(w3.gif_path)
-        w3.gif_image = Gtk.Image.new_from_animation(w3.anim)
-        w3.box_gif.pack_start(w3.gif_image, True, True, 0)
+        w3.load_gif(os.path.join(self.base_dir, "GIF3.gif"))
 
         w3.left_arrow.connect("clicked", self.on_left_click)
         w3.right_arrow.connect("clicked", self.on_right_click)
@@ -135,10 +128,7 @@ class TutorialWindows:
             "\n"
             "\nIt's all done, Good Luck and have fun!!!")
 
-        wn.gif_path = "GIF4.gif"
-        wn.anim = GdkPixbuf.PixbufAnimation.new_from_file(wn.gif_path)
-        wn.gif_image = Gtk.Image.new_from_animation(wn.anim)
-        wn.box_gif.pack_start(wn.gif_image, True, True, 0)
+        wn.load_gif(os.path.join(self.base_dir, "GIF4.gif"))
 
         wn.right_arrow.destroy()  # Last Window doesn't have a right arrow
         wn.left_arrow.connect("clicked", self.on_left_click)
@@ -209,14 +199,22 @@ class TutorialWindow(Gtk.Window):
         self.description_label.set_line_wrap(True)
         self.vbox.pack_start(self.description_label, False, False, 10)
 
-    def on_replay_click(self, button):
-        self.gif_image.destroy()
+    def load_gif(self, path):
+        if self.gif_image:
+            self.gif_image.destroy()
 
-        self.anim = GdkPixbuf.PixbufAnimation.new_from_file(self.gif_path)
-        self.gif_image = Gtk.Image.new_from_animation(self.anim)
+        self.gif_path = path
+        try:
+            self.anim = GdkPixbuf.PixbufAnimation.new_from_file(self.gif_path)
+            self.gif_image = Gtk.Image.new_from_animation(self.anim)
+        except Exception as e:
+            self.gif_image = Gtk.Label(label="Failed to load image!\nPath: " + self.gif_path + "\nError: " + str(e))
+            
         self.box_gif.pack_start(self.gif_image, True, True, 0)
+        self.box_gif.show_all()
 
-        self.show_all()
+    def on_replay_click(self, button):
+        self.load_gif(self.gif_path)
 
 
 def add_section(help_box, section_text, icon=None):

--- a/TurtleArt/util/helpbutton.py
+++ b/TurtleArt/util/helpbutton.py
@@ -29,6 +29,7 @@ from sugar3.graphics.icon import Icon
 
 from TurtleArt.tapalette import help_windows
 
+from pathlib import Path
 import os
 import logging
 _logger = logging.getLogger('turtleart-activity')
@@ -62,7 +63,7 @@ class HelpButton(Gtk.ToolItem):
 class TutorialWindows:
     def __init__(self):
         self.array = []
-        self.base_dir = os.getcwd()
+        self.base_dir = Path(__file__).resolve().parents[2]
 
         # Current Index of the Window we are at
         self.curr = 0

--- a/TurtleArt/util/odf/element.py
+++ b/TurtleArt/util/odf/element.py
@@ -270,7 +270,7 @@ class Text(Childless, Node):
             f.write(_escape(str(self.data).encode('utf-8')))
 
 
-class CDATASection(Childless, Text):
+class CDATASection(Text):
     nodeType = Node.CDATA_SECTION_NODE
 
     def toXml(self, level, f):

--- a/gnome_plugins/collaboration_plugin.py
+++ b/gnome_plugins/collaboration_plugin.py
@@ -21,8 +21,6 @@
 # THE SOFTWARE.
 
 import sys
-
-sys.path.append("..")
 import os.path
 
 import dbus
@@ -200,8 +198,8 @@ class Collaboration_plugin(Plugin):
     def _activity_removed_cb(self, model, activity_model):
         try:
             self._activities.pop(activity_model.props.name)
-        except BaseException:
-            print('Failed to remove activity %s' % activity_model.props.name)
+        except Exception as e:
+            print('Failed to remove activity %s: %s' % (activity_model.props.name, e))
 
         self._recreate_available_activities_menu()
 
@@ -212,8 +210,8 @@ class Collaboration_plugin(Plugin):
     def _buddy_removed_cb(self, activity, buddy):
         try:
             self._buddies.pop(buddy.get_key())
-        except BaseException:
-            print("Couldn't remove buddy %s" % buddy.get_key())
+        except Exception as e:
+            print("Couldn't remove buddy %s: %s" % (buddy.get_key(), e))
         self._recreate_available_buddies_menu()
 
     # TODO: we should have a list of available actions over
@@ -271,7 +269,7 @@ class Collaboration_plugin(Plugin):
                 account_path, connection, room_handle, properties=properties)
             # FIXME: this should be unified, no need to keep 2 references
             self.shared_activity = self._joined_activity
-        except BaseException:
+        except Exception:
             traceback.print_exc(file=sys.stdout)
 
         if self._joined_activity.props.joined:
@@ -332,7 +330,7 @@ class Collaboration_plugin(Plugin):
                                                     properties=properties)
             # FIXME: this should be unified, no need to keep 2 references
             self.shared_activity = self._parent.shared_activity
-        except BaseException:
+        except Exception:
             traceback.print_exc(file=sys.stdout)
 
         if self._parent._shared_parent.props.joined:

--- a/gnome_plugins/fb_plugin.py
+++ b/gnome_plugins/fb_plugin.py
@@ -31,6 +31,7 @@
 # project. Please report any problems to rgs and walter.
 
 
+import os
 import pycurl
 import urllib.parse
 
@@ -39,8 +40,7 @@ from gi.repository import Gtk
 try:
     from gi.repository import WebKit
     HAS_WEBKIT = True
-except BaseException:
-    pass
+except (ValueError, ImportError):
     HAS_WEBKIT = False
 from .plugin import Plugin
 from TurtleArt.util.menubuilder import make_menu_item, make_sub_menu, MENUBAR
@@ -61,6 +61,7 @@ class FbUploader():
         c.setopt(c.HTTPPOST, self._get_params(c))
         c.perform()
         print(c.getinfo(c.HTTP_CODE))
+        c.close()
 
     def _get_url(self):
         return self.UPLOAD_URL % (self._access_token)
@@ -98,7 +99,7 @@ class Fb_plugin(Plugin):
         self.tw = turtleart_window
 
     def enabled(self):
-        return True
+        return HAS_WEBKIT
 
     def _post_menu_cb(self, widget):
 
@@ -151,3 +152,8 @@ class Fb_plugin(Plugin):
         ta_file, image_file = self.tw.save_for_upload("ta fb")
         uploader = FbUploader(image_file, self._access_token)
         uploader.doit()
+        
+        if os.path.exists(image_file):
+            os.remove(image_file)
+        if os.path.exists(ta_file):
+            os.remove(ta_file)

--- a/gnome_plugins/uploader_plugin.py
+++ b/gnome_plugins/uploader_plugin.py
@@ -78,7 +78,7 @@ class Uploader_plugin(Plugin):
         if self.uploading:
             return
 
-        self.uploading = False
+        self.uploading = True
         self.pop_up = Gtk.Window()
         self.pop_up.set_default_size(600, 400)
         self.pop_up.connect('delete_event', self._stop_uploading)
@@ -153,7 +153,6 @@ http://turtleartsite.sugarlabs.org to upload your project.'))
 
     def _do_remote_logon(self, widget):
         """ Log into the upload server """
-        import socket
 
         username = self.username_entry.get_text()
         password = self.password_entry.get_text()
@@ -162,7 +161,7 @@ http://turtleartsite.sugarlabs.org to upload your project.'))
         logged_in = None
         try:
             logged_in = server.login_remote(username, password)
-        except socket.gaierror as e:
+        except Exception as e:
             print("Login failed %s" % e)
         if logged_in:
             upload_key = logged_in
@@ -174,17 +173,17 @@ http://turtleartsite.sugarlabs.org to upload your project.'))
         """ Submit project to the server """
         title = self.title_entry.get_text()
         description = self.description_entry.get_buffer().get_text(
-            *self.description_entry.get_buffer().get_bounds())
+            *self.description_entry.get_buffer().get_bounds(), True)
         tafile, imagefile = self.tw.save_for_upload(title)
 
         # Set a maximum file size for image to be uploaded.
         if int(os.path.getsize(imagefile)) > self._max_file_size:
-            import Image
+            from PIL import Image
             while int(os.path.getsize(imagefile)) > self._max_file_size:
-                big_file = Image.open(imagefile)
-                smaller_file = big_file.resize(int(0.9 * big_file.size[0]),
-                                               int(0.9 * big_file.size[1]),
-                                               Image.ANTIALIAS)
+                with Image.open(imagefile) as big_file:
+                    smaller_file = big_file.resize(
+                        (int(0.9 * big_file.size[0]), int(0.9 * big_file.size[1])),
+                        getattr(Image, 'Resampling', Image).LANCZOS)
                 smaller_file.save(imagefile, quality=100)
 
         c = pycurl.Curl()
@@ -201,7 +200,7 @@ http://turtleartsite.sugarlabs.org to upload your project.'))
                                                     'image_create')])
         c.perform()
         error_code = c.getinfo(c.HTTP_CODE)
-        c.close
+        c.close()
         os.remove(imagefile)
         os.remove(tafile)
         if error_code == 400:


### PR DESCRIPTION
While auditing the codebase during the GTK4 port, several pre-existing bugs surfaced that are unrelated to the GTK3→4 migration itself — some are Python 2→3 leftovers, some are resource leaks, some are logic errors that predate this work entirely. These are being fixed now since they were found in the process, rather than left for a separate pass.

Each fix is its own commit so they can be reviewed, bisected, and reverted independently if any turns out to be wrong:

*   **`configwizard.py`** — window leaks and a Python 3 crash on invalid config
*   **`taplugin.py`** — plugin install crashes (wrong dict/list assumption, missing arg)
*   **`helpbutton.py`** — tutorial GIFs crash the app if missing or launched out-of-tree
*   **`fb_plugin.py` / `uploader_plugin.py`** — leaked files/handles, a broken re-entrance guard, a stale Pillow API call
*   **`util/odf/element.py`** — Python 3 MRO crash in CDATASection
*   **`collaboration_plugin.py`** — narrowed overly-broad exception handlers, removed a fragile `sys.path` hack

---
*Note: This PR was split out from the main GTK4 migration PR #104 to keep the toolkit port history clean and bisectable.*
